### PR TITLE
Ensure log directory is created

### DIFF
--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -119,4 +119,8 @@ define newrelic::php (
     notify  => Service[$newrelic_php_service],
   }
 
+  file { '/var/log/newrelic/':
+    ensure => 'directory',
+  }
+
 }


### PR DESCRIPTION
Otherwise, the daemon won't start:

```
% sudo /etc/init.d/newrelic-daemon start
Starting New Relic Daemon: newrelic-daemonERROR: log file
'/var/log/newrelic/newrelic-daemon.log' could not be opened - cannot
continue.
 FAILED
```
