### PR TITLE
Add parameter to set newrelic.ini 'newrelic.ignored_params' option.

### DIFF
--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -64,6 +64,7 @@ define newrelic::php (
   $newrelic_php_conf_dberrors             = '0',
   $newrelic_php_conf_transactionrecordsql = 'off',
   $newrelic_php_conf_captureparams        = '0',
+  $newrelic_php_conf_ignoredparams        = '',
   $newrelic_daemon_pidfile                = '/var/run/newrelic-daemon.pid',
   $newrelic_daemon_logfile                = '/var/log/newrelic/newrelic-daemon.log',
   $newrelic_daemon_loglevel               = 'info',

--- a/templates/newrelic.ini.erb
+++ b/templates/newrelic.ini.erb
@@ -9,4 +9,5 @@ newrelic.transaction_tracer.detail = <%= @newrelic_php_conf_transaction %>
 newrelic.error_collector.record_database_errors = <%= @newrelic_php_conf_dberrors %>
 newrelic.transaction_tracer.record_sql = "<%= @newrelic_php_conf_transactionrecordsql %>"
 newrelic.capture_params = <%= @newrelic_php_conf_captureparams %>
+newrelic.ignored_params = "<%= @newrelic_php_conf_ignoredparams %>"
 newrelic.daemon.port = <%= @newrelic_daemon_port %>


### PR DESCRIPTION
As the underlying parameter, value should be a gingle, comma-separated string.
It could be done via an array with a join() call, but it would add a dependency on puppetlabs/stdlib and I assumed it's a worse solution.
