### PR TITLE
add a parameter for newrelic_daemon_cfgfile_ensure

### DIFF
--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -71,7 +71,7 @@ define newrelic::php (
   $newrelic_daemon_logfile                = '/var/log/newrelic/newrelic-daemon.log',
   $newrelic_daemon_loglevel               = 'info',
   $newrelic_daemon_port                   = '33142',
-  $newrelic_daemon_ssl                    = 'false',
+  $newrelic_daemon_ssl                    = false,
   $newrelic_daemon_proxy                  = '',
   $newrelic_daemon_ssl_ca_bundle          = '',
   $newrelic_daemon_ssl_ca_path            = '',


### PR DESCRIPTION
cfgfile needs to be absent for agent startup mode but your module couldn't do this yet, defaults to true to maintain compatibility

https://docs.newrelic.com/docs/php/starting-the-php-daemon
