### PR TITLE
Fix PHP conf dir for Ubuntu 14.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,7 @@ class newrelic::params {
       $newrelic_service_name  = 'newrelic-sysmond'
       $newrelic_php_package   = 'newrelic-php5'
       $newrelic_php_service   = 'newrelic-daemon'
-      $newrelic_php_conf_dir  = '/etc/php.d'
+      $newrelic_php_conf_dir  = ['/etc/php.d']
       package { 'newrelic-repo-5-3.noarch':
         ensure   => present,
         source   => 'http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm',
@@ -30,7 +30,12 @@ class newrelic::params {
       $newrelic_service_name  = 'newrelic-sysmond'
       $newrelic_php_package   = 'newrelic-php5'
       $newrelic_php_service   = 'newrelic-daemon'
-      $newrelic_php_conf_dir  = '/etc/php5/conf.d'
+      if $::operatingsystemrelease == "14.04" {
+        $newrelic_php_conf_dir  = ['/etc/php5/cli/conf.d', '/etc/php5/fpm/conf.d']
+      }
+      else {
+        $newrelic_php_conf_dir  = ['/etc/php5/conf.d']
+      }
       apt::source { 'newrelic':
         location    => 'http://apt.newrelic.com/debian/',
         repos       => 'newrelic non-free',

--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -105,15 +105,11 @@ define newrelic::php (
     provider    => 'shell',
     user        => 'root',
     group       => 'root',
-    unless      => "cat ${newrelic_php_conf_dir}/newrelic.ini | grep ${newrelic_license_key}",
+    unless      => "grep ${newrelic_license_key} ${newrelic_php_conf_dir[0]}/newrelic.ini",
     require     => Package[$newrelic_php_package],
   }
 
-  file { 'newrelic.ini':
-    path    => "${newrelic_php_conf_dir}/newrelic.ini",
-    content => template('newrelic/newrelic.ini.erb'),
-    require => Exec['/usr/bin/newrelic-install'],
-  }
+  newrelic_ini { $newrelic_php_conf_dir: }
 
   file { '/etc/newrelic/newrelic.cfg':
     ensure  => $newrelic_daemon_cfgfile_ensure,
@@ -124,4 +120,12 @@ define newrelic::php (
     notify  => Service[$newrelic_php_service],
   }
 
+}
+
+define newrelic_ini {
+  file { "${name}/newrelic.ini":
+    path    => "${name}/newrelic.ini",
+    content => template('newrelic/newrelic.ini.erb'),
+    require => Exec['/usr/bin/newrelic-install'],
+  }
 }


### PR DESCRIPTION
This consider the new PHP conf.d directory structure for Ubuntu 14.04 LTS. Basically, now we don't have the base conf.d dir anymore.

 This is working, but it's just a first path. Somethings that I don't like about it:
- The `unless` check for `newrelic.ini`
- I had to change `$newrelic_php_conf_dir` to an array

Feedback welcomed!
