### PR TITLE
Remove unneeded exec

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -94,17 +94,6 @@ define newrelic::server (
     enable     => $newrelic_service_enable,
     hasrestart => true,
     hasstatus  => true,
-    require    => Exec[$newrelic_license_key],
-  }
-
-  exec { $newrelic_license_key:
-    path        => '/bin:/usr/bin',
-    command     => "/usr/sbin/nrsysmond-config --set license_key=${newrelic_license_key}",
-    user        => 'root',
-    group       => 'root',
-    unless      => "cat /etc/newrelic/nrsysmond.cfg | grep ${newrelic_license_key}",
-    require     => Package[$newrelic_package_name],
-    notify      => Service[$newrelic_service_name],
   }
 
 }


### PR DESCRIPTION
As the license key is set in the nrsysmond.cfg template there's no need to
use an extra command to set it - the file is already generated before the service
is notified.
