### PR TITLE
Fixed PHP deprecated notice

### DIFF
--- a/templates/newrelic.ini.erb
+++ b/templates/newrelic.ini.erb
@@ -326,7 +326,7 @@ newrelic.daemon.collector_host = "<%= @newrelic_daemon_collector_host %>"
 ;          parameters are simply used for parameters without sensitive data but
 ;          that are meaningful to each transaction then you can enable this.
 ;
-#newrelic.capture_params = true
+;newrelic.capture_params = true
 <%- if @newrelic_ini_capture_params -%>
 newrelic.capture_params = "<%= @newrelic_ini_capture_params %>"
 <%- end -%>


### PR DESCRIPTION
Fixes this: "PHP Deprecated:  Comments starting with '#' are deprecated in /etc/php5/cli/conf.d/20-newrelic.ini on line 283 in Unknown on line 0"
