### PR TITLE
Use the facter value of $::path for newrelic php install

### DIFF
--- a/manifests/agent/php.pp
+++ b/manifests/agent/php.pp
@@ -34,6 +34,7 @@ class newrelic::agent::php (
   $newrelic_php_package_ensure                           = 'present',
   $newrelic_php_service_ensure                           = 'running',
   $newrelic_php_conf_dir                                 = $::newrelic::params::newrelic_php_conf_dir,
+  $newrelic_php_exec_path                                = $::path,
   $newrelic_php_package                                  = $::newrelic::params::newrelic_php_package,
   $newrelic_php_service                                  = $::newrelic::params::newrelic_php_service,
   $newrelic_license_key                                  = undef,
@@ -90,6 +91,7 @@ class newrelic::agent::php (
   }
 
   ::newrelic::php::newrelic_ini { $newrelic_php_conf_dir:
+    exec_path            => $newrelic_php_exec_path,
     newrelic_license_key => $newrelic_license_key,
     before               => [ File['/etc/newrelic/newrelic.cfg'], Service[$newrelic_php_service] ],
     require              => Package[$newrelic_php_package],

--- a/manifests/php/newrelic_ini.pp
+++ b/manifests/php/newrelic_ini.pp
@@ -1,10 +1,11 @@
 # This module should not be used directly. It is used by newrelic::php.
 define newrelic::php::newrelic_ini (
-  $newrelic_license_key
+  $newrelic_license_key,
+  $exec_path,
 ) {
 
   exec { "/usr/bin/newrelic-install ${name}":
-    path     => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    path     => $exec_path,
     command  => "/usr/bin/newrelic-install purge ; NR_INSTALL_SILENT=yes, NR_INSTALL_KEY=${newrelic_license_key} /usr/bin/newrelic-install install",
     provider => 'shell',
     user     => 'root',


### PR DESCRIPTION
Currently, the `path` parameter  in `newrelic::php::newrelic_ini` hardcodes the path for Exec{}.  This works fine for default php installations.  However, the `newrelic-install` binary is smart enough to find php if it's on your path.  We use RedHat Software Collections, which depends on `$PATH`.

This pull request solves the problem:
- Convenient for non-standard php installations
- Allows override if php isn't in the path by default
