### PR TITLE
Use key fingerprint instead of key ID for apt repo

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@ class newrelic::params {
       apt::source { 'newrelic':
         location    => 'http://apt.newrelic.com/debian/',
         repos       => 'non-free',
-        key         => '548C16BF',
+        key         => 'B60A3EC9BC013B9C23790EC8B31B29E5548C16BF',
         key_source  => 'https://download.newrelic.com/548C16BF.gpg',
         include_src => false,
         release     => 'newrelic',


### PR DESCRIPTION
As of v1.8.0, Puppetlabs' apt module issues warnings when using short GPG key IDs rather than the full fingerprint. This fixes the warning.