### PR TITLE
Puppetlabs-apt module (v1.8.0) seeks full gpg fingerprint (40 characters...

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,11 +29,12 @@ class newrelic::params {
       $newrelic_package_name  = 'newrelic-sysmond'
       $newrelic_service_name  = 'newrelic-sysmond'
       $newrelic_php_package   = 'newrelic-php5'
+      $newrelic_key           = '548C16BF'
       $newrelic_php_service   = 'newrelic-daemon'
       apt::source { 'newrelic':
         location    => 'http://apt.newrelic.com/debian/',
         repos       => 'non-free',
-        key         => '548C16BF',
+        key         => $newrelic_key,
         key_source  => 'https://download.newrelic.com/548C16BF.gpg',
         include_src => false,
         release     => 'newrelic',


### PR DESCRIPTION
...). This allows for overiding while still preserving current code.

I.e. B60A3EC9BC013B9C23790EC8B31B29E5548C16BF