### PR TITLE
Notify the NewRelic daemon when the NewRelic PHP agent is updated

### DIFF
--- a/manifests/agent/php.pp
+++ b/manifests/agent/php.pp
@@ -81,6 +81,7 @@ class newrelic::agent::php (
 
   package { $newrelic_php_package:
     ensure  => $newrelic_php_package_ensure,
+    notify  => Package[$newrelic_php_package],
     require => Class['newrelic::params'],
   }
 


### PR DESCRIPTION
It seems that when `Package[$newrelic_php_package]` is updated, `Service[$newrelic_php_service]` is not restarted. As a result, I was seeing the following errors in the log files:

```
2015-04-12 18:11:58.377 (10896 10897) error: protocol version mismatch daemon=4:8:0 agent=4:7:0.
2015-04-12 18:11:58.377 (10896 10897) error: agent version is older than the newrelic-daemon, this may be due to a software update. Try
restarting the agent.
```
