### PR TITLE
Restart PHP FPM when NewRelic package is updated

### DIFF
--- a/manifests/agent/php.pp
+++ b/manifests/agent/php.pp
@@ -73,6 +73,7 @@ class newrelic::agent::php (
   $newrelic_daemon_proxy                                 = undef,
   $newrelic_daemon_collector_host                        = undef,
   $newrelic_daemon_auditlog                              = undef,
+  $phpfpm_service_name                                   = $::newrelic::params::phpfpm_service_name,
 ) inherits ::newrelic {
 
   if ! $newrelic_license_key {
@@ -89,6 +90,10 @@ class newrelic::agent::php (
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
+  }
+
+  if $phpfpm_service_name != undef {
+    Package[$newrelic_php_package] ~> Service[$phpfpm_service_name]
   }
 
   ::newrelic::php::newrelic_ini { $newrelic_php_conf_dir:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,7 @@ class newrelic::params {
       $newrelic_php_package   = 'newrelic-php5'
       $newrelic_php_service   = 'newrelic-daemon'
       $newrelic_php_conf_dir  = ['/etc/php.d']
+      $phpfpm_service_name    = 'php-fpm'
       package { 'newrelic-repo-5-3.noarch':
         ensure   => present,
         source   => 'http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm',
@@ -30,6 +31,7 @@ class newrelic::params {
       $newrelic_service_name  = 'newrelic-sysmond'
       $newrelic_php_package   = 'newrelic-php5'
       $newrelic_php_service   = 'newrelic-daemon'
+      $phpfpm_service_name    = 'php5-fpm'
       apt::source { 'newrelic':
         location    => 'http://apt.newrelic.com/debian/',
         repos       => 'non-free',


### PR DESCRIPTION
The `php5-fpm` service should be restarted when the NewRelic package is updated.
