### PR TITLE
apt::key updated to 40chars

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@ class newrelic::params {
       apt::source { 'newrelic':
         location    => 'http://apt.newrelic.com/debian/',
         repos       => 'non-free',
-        key         => '548C16BF',
+        key         => 'B60A3EC9BC013B9C23790EC8B31B29E5548C16BF',
         key_source  => 'https://download.newrelic.com/548C16BF.gpg',
         include_src => false,
         release     => 'newrelic',


### PR DESCRIPTION
Fix Warning: /Apt_key[Add key: 548C16BF from Apt::Source newrelic]: The id should be a full fingerprint (40 characters), see README.

Regards

M