### PR TITLE
Cater for puppetlabs apt (2.0.1) refactoring.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,9 +33,13 @@ class newrelic::params {
       apt::source { 'newrelic':
         location    => 'http://apt.newrelic.com/debian/',
         repos       => 'non-free',
-        key         => '548C16BF',
-        key_source  => 'https://download.newrelic.com/548C16BF.gpg',
-        include_src => false,
+        key         => {
+          id         => 'B60A3EC9BC013B9C23790EC8B31B29E5548C16BF',
+          key_source => 'https://download.newrelic.com/548C16BF.gpg',
+        },
+        include => {
+          src => false,
+        },
         release     => 'newrelic',
       }
       case $::operatingsystem {


### PR DESCRIPTION
Good day

The puppet labs apt module has changed the way apt::source handles a few definition variables.
I.e. Variables include and key.

Please see my pull request.
Kind Regards
Brent Clark