### PR TITLE
Adding support for Windows server agent and .Net agents.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Supported systems: Debian and RHEL osfamily Linux.
 Operating System
 ----------------
 
-Tested on CentOS, Debian and Ubuntu.
+Tested on CentOS, Debian, Ubuntu and Windows.
 
 IMPORTANT
 ---------
@@ -36,6 +36,20 @@ To install the Newrelic Server Monitoring and the PHP agent packages, include th
            newrelic_ini_appname  => 'Your PHP Application',
          }
     }
+
+To do the same for a Windows .Net host, include the following:
+
+    node default {
+         class {'newrelic::server::windows':
+           newrelic_license_key => 'your license key here',
+         }
+
+         class {'newrelic::agent::dotnet':
+           newrelic_license_key  => 'your license key here',
+         }
+    }
+
+(Note that, while it is possible to specify a version of the .Net agent, caution should be excercised if doing this. Newrelic make only the last two releases available on http://download.newrelic.com/dot_net_agent/release/.)
 
 If you use Ubuntu 14.04 and php5-fpm you can pass an array of directories for PHP ini files:
 

--- a/manifests/agent/dotnet.pp
+++ b/manifests/agent/dotnet.pp
@@ -1,0 +1,79 @@
+# Class: newrelic::agent::dotnet
+#
+# This class install the New Relic .Net Agent
+#
+# Parameters:
+#
+# [*newrelic_dotnet_package_ensure*]
+#   Specific the Newrelic .Net package update state. Defaults to 'present'. Possible values are specific versions of the agent.
+#   Note that, if you specifiy a specific version, you will need to keep this regularly updated, as NewRelic only retain the last two releases on their download site.
+#
+# [*newrelic_dotnet_cfgfile_ensure*]
+#   Specify the Newrelic daemon cfg file state. Change to absent for agent startup mode. Defaults to 'present'. Possible value is 'absent'.
+#
+# Actions:
+#
+# Requires:
+#
+# Sample Usage:
+#
+#  class {'newrelic::agent::dotnet':
+#      newrelic_license_key           => 'your license key here',
+#      newrelic_dotnet_package_ensure => 'latest',
+#    }
+#
+# If no parameters are set it will use the newrelic.config defaults
+#
+# For detailed explanation about the parameters below see: https://docs.newrelic.com/docs/php/php-agent-phpini-settings
+#
+class newrelic::agent::dotnet (
+  $newrelic_dotnet_package_ensure                        = 'present',
+  $newrelic_dotnet_conf_dir                              = $::newrelic::params::newrelic_dotnet_conf_dir,
+  $newrelic_dotnet_package                               = $::newrelic::params::newrelic_dotnet_package,
+  $newrelic_license_key                                  = undef,
+  $newrelic_daemon_cfgfile_ensure                        = 'present',
+  $temp_dir                                              = $::newrelic::params::temp_dir ,
+  $newrelic_dotnet_source                                = $::newrelic::params::newrelic_dotnet_source,
+) inherits ::newrelic {
+
+  if ! $newrelic_license_key {
+    fail('You must specify a valid License Key.')
+  }
+  
+  case $newrelic_dotnet_package_ensure {
+    'absent':   {
+      $package_source = false
+    }
+    'present','installed':  {
+      $package_source   = "${newrelic_dotnet_source}/NewRelicDotNetAgent_${::architecture}.msi"
+      $destination_file = "NewRelicDotNetAgent_${::architecture}.msi"
+    }
+    'latest':   {
+      fail("'latest' is not a valid value for this package, as we have no way of determining which version is the latest one. You can specify a specific version, though.")
+    }
+    default:    {
+      $package_source   = "${newrelic_dotnet_source}/NewRelicDotNetAgent_${::architecture}_${newrelic_dotnet_package_ensure}.msi"
+      $destination_file = "NewRelicDotNetAgent_${::architecture}_${newrelic_dotnet_package_ensure}.msi"
+    }
+  }
+  
+  if $package_source {
+    download_file {$destination_file:
+      url                   => $package_source,
+      destination_directory => $temp_dir,
+      destination_file      => $destination_file,
+      before                => Package[$newrelic_dotnet_package],
+    }
+  }
+
+  package { $newrelic_dotnet_package:
+    ensure  => $newrelic_dotnet_package_ensure,
+    source  => "${temp_dir}\\${destination_file}",
+    require => Class['newrelic::params'],
+  } ->
+  file { "${newrelic_dotnet_conf_dir}\\newrelic.config":
+    ensure  => $newrelic_daemon_cfgfile_ensure,
+    content => template('newrelic/newrelic.config.erb'),
+  }
+
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,8 +64,18 @@ class newrelic::params {
         }
       }
     }
+    'windows': {
+      $bitness                        = regsubst($::architecture,'^x([\d]{2})','\1')
+      $newrelic_package_name          = 'New Relic Server Monitor'
+      $newrelic_service_name          = 'nrsvrmon'
+      $temp_dir                       = 'C:/Windows/temp'
+      $server_monitor_source          = 'http://download.newrelic.com/windows_server_monitor/release/'    
+      $newrelic_dotnet_conf_dir       = 'C:\\ProgramData\\New Relic\\.NET Agent'
+      $newrelic_dotnet_package        = "New Relic .NET Agent (${bitness}-bit)"
+      $newrelic_dotnet_source         = 'http://download.newrelic.com/dot_net_agent/release/'
+    }
     default: {
-      fail("Unsupported osfamily: ${::osfamily} operatingsystem: ${::operatingsystem}, module ${module_name} only support osfamily RedHat and Debian")
+      fail("Unsupported osfamily: ${::osfamily} operatingsystem: ${::operatingsystem}")
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -69,7 +69,7 @@ class newrelic::params {
       $newrelic_package_name          = 'New Relic Server Monitor'
       $newrelic_service_name          = 'nrsvrmon'
       $temp_dir                       = 'C:/Windows/temp'
-      $server_monitor_source          = 'http://download.newrelic.com/windows_server_monitor/release/'    
+      $server_monitor_source          = 'http://download.newrelic.com/windows_server_monitor/release/'
       $newrelic_dotnet_conf_dir       = 'C:\\ProgramData\\New Relic\\.NET Agent'
       $newrelic_dotnet_package        = "New Relic .NET Agent (${bitness}-bit)"
       $newrelic_dotnet_source         = 'http://download.newrelic.com/dot_net_agent/release/'

--- a/manifests/server/windows.pp
+++ b/manifests/server/windows.pp
@@ -80,8 +80,8 @@ class newrelic::server::windows (
     notify          => Service[$newrelic_service_name],
     source          => "${temp_dir}\\${destination_file}",
     install_options => [
-      '/L*v', 
-      "${temp_dir}\\NewRelicServerMonitor_install.log", 
+      '/L*v',
+      "${temp_dir}\\NewRelicServerMonitor_install.log",
       {
         'NR_LICENSE_KEY' => $newrelic_license_key
       }

--- a/manifests/server/windows.pp
+++ b/manifests/server/windows.pp
@@ -1,0 +1,94 @@
+# == Class: newrelic::server::windows
+#
+# This class installs and configures NewRelic server monitoring.
+#
+# === Parameters
+#
+# [*newrelic_service_enable*]
+#   Specify the service startup state. Defaults to true. Possible value is false.
+#
+# [*newrelic_service_ensure*]
+#   Specify the service running state. Defaults to 'running'. Possible value is 'stopped'.
+#
+# [*newrelic_package_ensure*]
+#   Specify the package update state. Defaults to 'present'. Possible values are specific versions of the server agent.
+#
+# [*newrelic_license_key*]
+#   Specify your Newrelic License Key.
+#
+# === Variables
+#
+# === Examples
+#
+#  class {'newrelic::server::linux':
+#      newrelic_license_key    => 'your license key here',
+#      newrelic_package_ensure => 'latest',
+#      newrelic_service_ensure => 'running',
+#  }
+#
+# === Authors
+#
+# Ben Priestman <ben.priestman@immediate.co.uk>
+#
+# === Copyright
+#
+# Copyright 20125 Ben Priestman, unless otherwise noted.
+#
+class newrelic::server::windows (
+  $newrelic_package_ensure           = 'present',
+  $newrelic_service_enable           = true,
+  $newrelic_service_ensure           = 'running',
+  $newrelic_license_key              = undef,
+  $newrelic_package_name             = $::newrelic::params::newrelic_package_name,
+  $newrelic_service_name             = $::newrelic::params::newrelic_service_name,
+  $temp_dir                          = $::newrelic::params::temp_dir ,
+  $server_monitor_source             = $::newrelic::params::server_monitor_source,
+) inherits ::newrelic {
+
+  if ! $newrelic_license_key {
+    fail('You must specify a valid License Key.')
+  }
+
+  case $newrelic_package_ensure {
+    'absent':   {
+      $package_source = false
+    }
+    'present','installed':  {
+      $package_source   = "${server_monitor_source}/${::architecture}"
+      $destination_file = "NewRelicServerMonitor_${::architecture}.msi"
+    }
+    'latest':   {
+      fail("'latest' is not a valid value for this package, as we have no way of determining which version is the latest one. You can specify a specific version, though.")
+    }
+    default:    {
+      $package_source   = "${server_monitor_source}/NewRelicServerMonitor_${::architecture}_${newrelic_package_ensure}.msi"
+      $destination_file = "NewRelicServerMonitor_${::architecture}_${newrelic_package_ensure}.msi"
+    }
+  }
+  
+  if $package_source {
+    download_file {$destination_file:
+      url                   => $package_source,
+      destination_directory => $temp_dir,
+      destination_file      => $destination_file,
+      before                => Package[$newrelic_package_name],
+    }
+  }
+  
+  package { $newrelic_package_name:
+    ensure          => $newrelic_package_ensure,
+    notify          => Service[$newrelic_service_name],
+    source          => "${temp_dir}\\${destination_file}",
+    install_options => ['/L*v', "${temp_dir}\\NewRelicServerMonitor_install.log", {'NR_LICENSE_KEY' => "$newrelic_license_key"}],
+    require         => Class['newrelic::params'],
+  }
+
+  service { $newrelic_service_name:
+    ensure     => $newrelic_service_ensure,
+    enable     => $newrelic_service_enable,
+    hasrestart => true,
+    hasstatus  => true,
+  }
+
+
+}

--- a/manifests/server/windows.pp
+++ b/manifests/server/windows.pp
@@ -79,7 +79,13 @@ class newrelic::server::windows (
     ensure          => $newrelic_package_ensure,
     notify          => Service[$newrelic_service_name],
     source          => "${temp_dir}\\${destination_file}",
-    install_options => ['/L*v', "${temp_dir}\\NewRelicServerMonitor_install.log", {'NR_LICENSE_KEY' => $newrelic_license_key}],
+    install_options => [
+      '/L*v', 
+      "${temp_dir}\\NewRelicServerMonitor_install.log", 
+      {
+        'NR_LICENSE_KEY' => $newrelic_license_key
+      }
+    ],
     require         => Class['newrelic::params'],
   }
 

--- a/manifests/server/windows.pp
+++ b/manifests/server/windows.pp
@@ -79,7 +79,7 @@ class newrelic::server::windows (
     ensure          => $newrelic_package_ensure,
     notify          => Service[$newrelic_service_name],
     source          => "${temp_dir}\\${destination_file}",
-    install_options => ['/L*v', "${temp_dir}\\NewRelicServerMonitor_install.log", {'NR_LICENSE_KEY' => "$newrelic_license_key"}],
+    install_options => ['/L*v', "${temp_dir}\\NewRelicServerMonitor_install.log", {'NR_LICENSE_KEY' => $newrelic_license_key}],
     require         => Class['newrelic::params'],
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -31,6 +31,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "puppet/download_file",
+      "version_requirement": ">= 1.2.1"
     }
   ]
 }

--- a/templates/newrelic.config.erb
+++ b/templates/newrelic.config.erb
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!-- Copyright (c) 2008-2014 New Relic, Inc.  All rights reserved. -->
+<!-- For more information see: https://newrelic.com/docs/dotnet/dotnet-agent-configuration -->
+<configuration xmlns="urn:newrelic-config" agentEnabled="true">
+  <service licenseKey="<%= @newrelic_license_key %>" ssl="true" />
+  <application>
+    <name>My Application</name>
+  </application>
+  <log level="info" />
+  <transactionTracer enabled="true" transactionThreshold="apdex_f" stackTraceThreshold="500" recordSql="obfuscated" explainEnabled="true" explainThreshold="500" />
+  <crossApplicationTracer enabled="true" />
+  <errorCollector enabled="true">
+    <ignoreErrors>
+      <exception>System.IO.FileNotFoundException</exception>
+      <exception>System.Threading.ThreadAbortException</exception>
+    </ignoreErrors>
+    <ignoreStatusCodes>
+      <code>401</code>
+      <code>404</code>
+    </ignoreStatusCodes>
+  </errorCollector>
+  <browserMonitoring autoInstrument="true" />
+  <threadProfiling>
+    <ignoreMethod>NewRelic.Agent.Core.HarvesterService:ThreadSleep</ignoreMethod>
+  </threadProfiling>
+</configuration>

--- a/tests/dotnet.pp
+++ b/tests/dotnet.pp
@@ -1,0 +1,35 @@
+# Install New Relic PHP Agent
+
+node default {
+
+  # Include main WebServer Role and standard modules
+  # windowsfeature is opentable/windows_feature
+  windowsfeature{'Web-Server': }
+  windowsfeature{'Web-WebServer': }
+  windowsfeature{'Web-Static-Content': }
+  windowsfeature{'Web-Default-Doc': }
+  windowsfeature{'Web-Dir-Browsing': }
+  windowsfeature{'Web-Http-Errors': }
+  windowsfeature{'Web-Http-Logging': }
+  windowsfeature{'Web-Request-Monitor': }
+  windowsfeature{'Web-Filtering': }
+  windowsfeature{'Web-Stat-Compression': }
+  windowsfeature{'Web-Mgmt-Console': }
+  
+  # Include .Net module
+  $dotnet_modules = $::operatingsystemrelease ? {
+    /2008/  => ['Web-Asp-Net'],
+    default => ['Web-Asp-Net','Web-Asp-Net45'],
+  }
+  ensure_resource ('windowsfeature', $dotnet_modules)
+
+  class {'newrelic::server::windows':
+    newrelic_license_key => '',
+  }
+
+  class {'newrelic::agent::dotnet':
+    newrelic_license_key   => '',
+    require                => Windowsfeature[$dotnet_modules],
+  }
+
+}


### PR DESCRIPTION
Note that Newrelic does not make available a repository for these binaries
comparable to yum or apt repos. In particular, only the last two releases
of the .Net agent are available, making management of particular versions
difficult. If a version is specified, it will need to be frequently
updated. 'latest' is not an option. Building in support for chocolatey
repos might be useful future addition.