### PR TITLE
added support for hostname override option in nrsysmond.cfg

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -50,6 +50,7 @@ define newrelic::server (
   $newrelic_nrsysmond_collector_host = undef,
   $newrelic_nrsysmond_labels         = undef,
   $newrelic_nrsysmond_timeout        = undef,
+  $newrelic_nrsysmond_hostname       = undef,
 ) {
 
   include newrelic

--- a/manifests/server/linux.pp
+++ b/manifests/server/linux.pp
@@ -51,6 +51,7 @@ class newrelic::server::linux (
   $newrelic_nrsysmond_collector_host = undef,
   $newrelic_nrsysmond_labels         = undef,
   $newrelic_nrsysmond_timeout        = undef,
+  $newrelic_nrsysmond_hostname       = undef,
 ) inherits ::newrelic {
 
   if ! $newrelic_license_key {

--- a/templates/nrsysmond.cfg.erb
+++ b/templates/nrsysmond.cfg.erb
@@ -169,3 +169,15 @@ labels=<%= @newrelic_nrsysmond_labels %>
 <%- if @newrelic_nrsysmond_timeout -%>
 timeout=<%= @newrelic_nrsysmond_timeout %>
 <%- end -%>
+
+#
+# Option : hostname
+# Value  : reports a different default server name to New Relic. This will
+#          appear in the New Relic user interface. See:
+#          https://docs.newrelic.com/docs/servers/new-relic-servers-linux/maintenance/changing-linux-server-name
+# Default: The system's actual hostname
+#
+# hostname=myserver-hostname
+<%- if @newrelic_nrsysmond_hostname -%>
+hostname=<%= @newrelic_nrsysmond_hostname %>
+<%- end -%>


### PR DESCRIPTION
In our deployments, we need to override the hostname that we report to New Relic, so we can tell certain servers apart in the UI.  New Relic supports this via the "hostname" option in nrsysmond.cfg, although it's only documented online, not in the cfg file itself.

See: https://docs.newrelic.com/docs/servers/new-relic-servers-linux/maintenance/changing-linux-server-name

Tested on Ubuntu 12.04 running on VirtualBox.