### PR TITLE
Include unofficial New Relic configurations

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -49,6 +49,7 @@ define newrelic::server (
   $newrelic_nrsysmond_pidfile        = undef,
   $newrelic_nrsysmond_collector_host = undef,
   $newrelic_nrsysmond_timeout        = undef,
+  $newrelic_nrsysmond_options        = {},
 ) {
 
   include newrelic

--- a/manifests/server/linux.pp
+++ b/manifests/server/linux.pp
@@ -50,6 +50,7 @@ class newrelic::server::linux (
   $newrelic_nrsysmond_pidfile        = undef,
   $newrelic_nrsysmond_collector_host = undef,
   $newrelic_nrsysmond_timeout        = undef,
+  $newrelic_nrsysmond_options        = {},
 ) inherits ::newrelic {
 
   if ! $newrelic_license_key {

--- a/templates/nrsysmond.cfg.erb
+++ b/templates/nrsysmond.cfg.erb
@@ -156,3 +156,10 @@ collector_host=<%= @newrelic_nrsysmond_collector_host %>
 <%- if @newrelic_nrsysmond_timeout -%>
 timeout=<%= @newrelic_nrsysmond_timeout %>
 <%- end -%>
+
+#
+# Below this line we include all the unofficial newrelic configuration
+#
+<%- newrelic_nrsysmond_options.each_pair do |key, value| -%>
+<%= key %>=<%= value %>
+<%- end -%>


### PR DESCRIPTION
New relic has some unofficial configuration that are not
documented. In the future this configurations could be
promoted to an official configuration an then it would
deserve an specific entry on our template. For now we
just included a generic hash option to allow this
configuration to be setted.

As an example, this feature could be used to set
configurations like ignore_reclaimable, proposed by
New Relic team on this post:

https://discuss.newrelic.com/t/memavailable-vs-memfree/12760/6
