### PR TITLE
set service provider to redhat on redhat systems

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,11 +14,12 @@ class newrelic::params {
 
   case $::osfamily {
     'RedHat': {
-      $newrelic_package_name  = 'newrelic-sysmond'
-      $newrelic_service_name  = 'newrelic-sysmond'
-      $newrelic_php_package   = 'newrelic-php5'
-      $newrelic_php_service   = 'newrelic-daemon'
-      $newrelic_php_conf_dir  = ['/etc/php.d']
+      $newrelic_package_name     = 'newrelic-sysmond'
+      $newrelic_service_name     = 'newrelic-sysmond'
+      $newrelic_service_provider = 'redhat'
+      $newrelic_php_package      = 'newrelic-php5'
+      $newrelic_php_service      = 'newrelic-daemon'
+      $newrelic_php_conf_dir     = ['/etc/php.d']
       package { 'newrelic-repo-5-3.noarch':
         ensure   => present,
         source   => 'http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm',
@@ -26,10 +27,11 @@ class newrelic::params {
       }
     }
     'Debian': {
-      $newrelic_package_name  = 'newrelic-sysmond'
-      $newrelic_service_name  = 'newrelic-sysmond'
-      $newrelic_php_package   = 'newrelic-php5'
-      $newrelic_php_service   = 'newrelic-daemon'
+      $newrelic_package_name     = 'newrelic-sysmond'
+      $newrelic_service_name     = 'newrelic-sysmond'
+      $newrelic_service_provider = undef
+      $newrelic_php_package      = 'newrelic-php5'
+      $newrelic_php_service      = 'newrelic-daemon'
       apt::source { 'newrelic':
         location => 'http://apt.newrelic.com/debian/',
         repos    => 'non-free',

--- a/manifests/server/linux.pp
+++ b/manifests/server/linux.pp
@@ -41,6 +41,7 @@ class newrelic::server::linux (
   $newrelic_license_key              = undef,
   $newrelic_package_name             = $::newrelic::params::newrelic_package_name,
   $newrelic_service_name             = $::newrelic::params::newrelic_service_name,
+  $newrelic_service_provider         = $::newrelic::params::newrelic_service_provider,
   $newrelic_nrsysmond_loglevel       = undef,
   $newrelic_nrsysmond_logfile        = undef,
   $newrelic_nrsysmond_proxy          = undef,
@@ -91,6 +92,7 @@ class newrelic::server::linux (
     enable     => $newrelic_service_enable,
     hasrestart => true,
     hasstatus  => true,
+    provider   => $newrelic_service_provider,
     require    => Exec[$newrelic_license_key],
   }
 


### PR DESCRIPTION
On EL7 systems the default provider does not correctly handle legacy init scripts, causing puppet to always change the service from stopped->running. Setting this to the 'redhat' provider allows puppet to correctly check the status of the service.
