### PR TITLE
Specify provider so it doesn't try to use an incorrect provider

### DIFF
--- a/manifests/server/windows.pp
+++ b/manifests/server/windows.pp
@@ -78,6 +78,7 @@ class newrelic::server::windows (
   package { $newrelic_package_name:
     ensure          => $newrelic_package_ensure,
     notify          => Service[$newrelic_service_name],
+    provider        => 'windows',
     source          => "${temp_dir}\\${destination_file}",
     install_options => [
       '/L*v',


### PR DESCRIPTION
Redoing https://github.com/fsalum/puppet-newrelic/pull/43, since I had deleted the original repo.

When I first setup this class on a Windows 2012 host, it failed stating that it needed chocolatey to install the package:

```
Failed to apply catalog:
  Parameter provider failed on Package[New Relic Server Monitor]:
    Invalid package provider 'chocolatey' at /etc/puppet/environments/production/modules/newrelic/manifests/server/windows.pp:90
    Wrapped exception: Invalid package provider 'chocolatey'
```

To get around this, I specify the **windows** provider, which is all that this PR contains.

Anything I can do to get this merged? Or any reason it's ignored?

In my environment, chocolatey is the default package provider on Windows hosts, which I don't want in this case. It seems reasonable to specify the proper provider. Or is there a workaround I can apply?
