### PR TITLE
Explicitly add PHP INI settings if they are defined

### DIFF
--- a/templates/newrelic.ini.erb
+++ b/templates/newrelic.ini.erb
@@ -23,7 +23,7 @@ extension = "newrelic.so"
 ;          disable the agent on a per-directory basis.
 ;
 ;newrelic.enabled = true
-<%- if scope['::newrelic::agent::php::newrelic_ini_enabled'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_enabled') != :undef -%>
 newrelic.enabled = <%= scope['::newrelic::agent::php::newrelic_ini_enabled'] %>
 <%- end -%>
 
@@ -61,7 +61,7 @@ newrelic.license = "<%= scope['::newrelic::agent::php::newrelic_license_key'] %>
 ; Default: none
 ; Info   : Sets the name of the file to send log messages to.
 ;
-<%- if scope['::newrelic::agent::php::newrelic_ini_logfile'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_logfile') != :undef -%>
 newrelic.logfile = "<%= scope['::newrelic::agent::php::newrelic_ini_logfile'] %>"
 <%- else -%>
 newrelic.logfile = "/var/log/newrelic/php_agent.log"
@@ -79,7 +79,7 @@ newrelic.logfile = "/var/log/newrelic/php_agent.log"
 ;            always, error, warning, info, verbose, debug, verbosedebug
 ;
 ;newrelic.loglevel = "info"
-<%- if scope['::newrelic::agent::php::newrelic_ini_loglevel'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_loglevel') != :undef -%>
 newrelic.loglevel = "<%= scope['::newrelic::agent::php::newrelic_ini_loglevel'] %>"
 <%- end -%>
 
@@ -108,7 +108,7 @@ newrelic.loglevel = "<%= scope['::newrelic::agent::php::newrelic_ini_loglevel'] 
 ;          will be collected.
 ;
 ;newrelic.high_security = false
-<%- if scope['::newrelic::agent::php::newrelic_ini_high_security'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_high_security') != :undef -%>
 newrelic.high_security = <%= scope['::newrelic::agent::php::newrelic_ini_high_security'] %>
 <%- end -%>
 
@@ -124,7 +124,7 @@ newrelic.high_security = <%= scope['::newrelic::agent::php::newrelic_ini_high_se
 ;          for each account / license key.
 ;
 ;newrelic.appname = "PHP Application"
-<%- if scope['::newrelic::agent::php::newrelic_ini_appname'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_appname') != :undef -%>
 newrelic.appname = "<%= scope['::newrelic::agent::php::newrelic_ini_appname'] %>"
 <%- end -%>
 
@@ -158,7 +158,7 @@ newrelic.appname = "<%= scope['::newrelic::agent::php::newrelic_ini_appname'] %>
 ; Default: none
 ; Info   : Sets the name of the file to send daemon log messages to.
 ;
-<%- if scope['::newrelic::agent::php::newrelic_daemon_logfile'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_daemon_logfile') != :undef -%>
 newrelic.daemon.logfile = "<%= scope['::newrelic::agent::php::newrelic_daemon_logfile'] %>"
 <%- else -%>
 newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
@@ -176,7 +176,7 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;            always, error, warning, info, verbose, debug, verbosedebug
 ;
 ;newrelic.daemon.loglevel = "info"
-<%- if scope['::newrelic::agent::php::newrelic_daemon_loglevel'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_daemon_loglevel') != :undef -%>
 newrelic.daemon.loglevel = "<%= scope['::newrelic::agent::php::newrelic_daemon_loglevel'] %>"
 <%- end -%>
 
@@ -194,7 +194,7 @@ newrelic.daemon.loglevel = "<%= scope['::newrelic::agent::php::newrelic_daemon_l
 ;          to use if you are using a chroot environment.
 ;
 ;newrelic.daemon.port = "/tmp/.newrelic.sock"
-<%- if scope['::newrelic::agent::php::newrelic_daemon_port'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_daemon_port') != :undef -%>
 newrelic.daemon.port = "<%= scope['::newrelic::agent::php::newrelic_daemon_port'] %>"
 <%- end -%>
 
@@ -207,7 +207,7 @@ newrelic.daemon.port = "<%= scope['::newrelic::agent::php::newrelic_daemon_port'
 ;          should use a secure HTTP connection or not.
 ;
 ;newrelic.daemon.ssl = true
-<%- if scope['::newrelic::agent::php::newrelic_daemon_ssl'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_daemon_ssl') != :undef -%>
 newrelic.daemon.ssl = <%= scope['::newrelic::agent::php::newrelic_daemon_ssl'] %>
 <%- end -%>
 
@@ -225,7 +225,7 @@ newrelic.daemon.ssl = <%= scope['::newrelic::agent::php::newrelic_daemon_ssl'] %
 ;          directory. This setting has no effect when newrelic.daemon.ssl
 ;          is set to false.
 ;newrelic.daemon.ssl_ca_bundle = ""
-<%- if scope['::newrelic::agent::php::newrelic_daemon_ssl_ca_bundle'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_daemon_ssl_ca_bundle') != :undef -%>
 newrelic.daemon.ssl_ca_bundle = "<%= scope['::newrelic::agent::php::newrelic_daemon_ssl_ca_bundle'] %>"
 <%- end -%>
 
@@ -242,7 +242,7 @@ newrelic.daemon.ssl_ca_bundle = "<%= scope['::newrelic::agent::php::newrelic_dae
 ;          newrelic.daemon.ssl_ca_path. This setting has no effect when
 ;          newrelic.daemon.ssl is set to false.
 ;newrelic.daemon.ssl_ca_path = ""
-<%- if scope['::newrelic::agent::php::newrelic_daemon_ssl_ca_path'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_daemon_ssl_ca_path') != :undef -%>
 newrelic.daemon.ssl_ca_path = "<%= scope['::newrelic::agent::php::newrelic_daemon_ssl_ca_path'] %>"
 <%- end -%>
 
@@ -263,7 +263,7 @@ newrelic.daemon.ssl_ca_path = "<%= scope['::newrelic::agent::php::newrelic_daemo
 ;             user:password@hostname:port
 ;
 ;newrelic.daemon.proxy = ""
-<%- if scope['::newrelic::agent::php::newrelic_daemon_proxy'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_daemon_proxy') != :undef -%>
 newrelic.daemon.proxy = "<%= scope['::newrelic::agent::php::newrelic_daemon_proxy'] %>"
 <%- end -%>
 
@@ -277,7 +277,7 @@ newrelic.daemon.proxy = "<%= scope['::newrelic::agent::php::newrelic_daemon_prox
 ;          script to determine whether or not the daemon is already running.
 ;
 ;newrelic.daemon.pidfile = ""
-<%- if scope['::newrelic::agent::php::newrelic_daemon_pidfile'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_daemon_pidfile') != :undef -%>
 newrelic.daemon.pidfile = "<%= scope['::newrelic::agent::php::newrelic_daemon_pidfile'] %>"
 <%- end -%>
 
@@ -292,7 +292,7 @@ newrelic.daemon.pidfile = "<%= scope['::newrelic::agent::php::newrelic_daemon_pi
 ;          /opt/newrelic/bin/newrelic-daemon.
 ;
 ;newrelic.daemon.location = "/usr/bin/newrelic-daemon"
-<%- if scope['::newrelic::agent::php::newrelic_daemon_location'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_daemon_location') != :undef -%>
 newrelic.daemon.location = "<%= scope['::newrelic::agent::php::newrelic_daemon_location'] %>"
 <%- end -%>
 
@@ -309,7 +309,7 @@ newrelic.daemon.location = "<%= scope['::newrelic::agent::php::newrelic_daemon_l
 ;          person or support staff member.
 ;
 ;newrelic.daemon.collector_host = "collector.newrelic.com"
-<%- if scope['::newrelic::agent::php::newrelic_daemon_collector_host'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_daemon_collector_host') != :undef -%>
 newrelic.daemon.collector_host = "<%= scope['::newrelic::agent::php::newrelic_daemon_collector_host'] %>"
 <%- end -%>
 
@@ -327,7 +327,7 @@ newrelic.daemon.collector_host = "<%= scope['::newrelic::agent::php::newrelic_da
 ;          that are meaningful to each transaction then you can enable this.
 ;
 ;newrelic.capture_params = true
-<%- if scope['::newrelic::agent::php::newrelic_ini_capture_params'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_capture_params') != :undef -%>
 newrelic.capture_params = "<%= scope['::newrelic::agent::php::newrelic_ini_capture_params'] %>"
 <%- end -%>
 
@@ -346,7 +346,7 @@ newrelic.capture_params = "<%= scope['::newrelic::agent::php::newrelic_ini_captu
 ;          3 - the agent will never start the daemon
 ;
 ;newrelic.daemon.dont_launch = 0
-<%- if scope['::newrelic::agent::php::newrelic_daemon_dont_launch'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_daemon_dont_launch') != :undef -%>
 newrelic.daemon.dont_launch = <%= scope['::newrelic::agent::php::newrelic_daemon_dont_launch'] %>
 <%- end -%>
 
@@ -361,7 +361,7 @@ newrelic.daemon.dont_launch = <%= scope['::newrelic::agent::php::newrelic_daemon
 ;          this to be disabled regardless of any value you set for it.
 ;
 ;newrelic.error_collector.enabled = true
-<%- if scope['::newrelic::agent::php::newrelic_ini_error_collector_enabled'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_error_collector_enabled') != :undef -%>
 newrelic.error_collector.enabled = <%= scope['::newrelic::agent::php::newrelic_ini_error_collector_enabled'] %>
 <%- end -%>
 
@@ -377,7 +377,7 @@ newrelic.error_collector.enabled = <%= scope['::newrelic::agent::php::newrelic_i
 ;          above and the account subscription level permits error trapping.
 ;
 ;newrelic.error_collector.record_database_errors = false
-<%- if scope['::newrelic::agent::php::newrelic_ini_error_collector_record_database_errors'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_error_collector_record_database_errors') != :undef -%>
 newrelic.error_collector.record_database_errors = <%= scope['::newrelic::agent::php::newrelic_ini_error_collector_record_database_errors'] %>
 <%- end -%>
 
@@ -391,7 +391,7 @@ newrelic.error_collector.record_database_errors = <%= scope['::newrelic::agent::
 ;          priority to such errors.
 ;
 ;newrelic.error_collector.prioritize_api_errors = false
-<%- if scope['::newrelic::agent::php::newrelic_ini_error_collector_prioritize_api_errors'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_error_collector_prioritize_api_errors') != :undef -%>
 newrelic.error_collector.prioritize_api_errors = <%= scope['::newrelic::agent::php::newrelic_ini_error_collector_prioritize_api_errors'] %>
 <%- end -%>
 
@@ -405,7 +405,7 @@ newrelic.error_collector.prioritize_api_errors = <%= scope['::newrelic::agent::p
 ;          in HTML output that will time the actual end-user experience.
 ;
 ;newrelic.browser_monitoring.auto_instrument = true
-<%- if scope['::newrelic::agent::php::newrelic_ini_browser_monitoring_auto_instrument'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_browser_monitoring_auto_instrument') != :undef -%>
 newrelic.browser_monitoring.auto_instrument = <%= scope['::newrelic::agent::php::newrelic_ini_browser_monitoring_auto_instrument'] %>
 <%- end -%>
 
@@ -424,7 +424,7 @@ newrelic.browser_monitoring.auto_instrument = <%= scope['::newrelic::agent::php:
 ;          regardless of what you set here.
 ;
 ;newrelic.transaction_tracer.enabled = true
-<%- if scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_enabled'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_transaction_tracer_enabled') != :undef -%>
 newrelic.transaction_tracer.enabled = <%= scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_enabled'] %>
 <%- end -%>
 
@@ -441,7 +441,7 @@ newrelic.transaction_tracer.enabled = <%= scope['::newrelic::agent::php::newreli
 ;          is the default.
 ;
 ;newrelic.transaction_tracer.threshold = "apdex_f"
-<%- if scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_threshold'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_transaction_tracer_threshold') != :undef -%>
 newrelic.transaction_tracer.threshold = "<%= scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_threshold'] %>"
 <%- end -%>
 
@@ -458,7 +458,7 @@ newrelic.transaction_tracer.threshold = "<%= scope['::newrelic::agent::php::newr
 ;          In earlier releases of the agent this was known as "top100".
 ;
 ;newrelic.transaction_tracer.detail = 1
-<%- if scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_detail'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_transaction_tracer_detail') != :undef -%>
 newrelic.transaction_tracer.detail = <%= scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_detail'] %>
 <%- end -%>
 
@@ -472,7 +472,7 @@ newrelic.transaction_tracer.detail = <%= scope['::newrelic::agent::php::newrelic
 ;          where the call occurred in your code.
 ;
 ;newrelic.transaction_tracer.slow_sql = true
-<%- if scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_slow_sql'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_transaction_tracer_slow_sql') != :undef -%>
 newrelic.transaction_tracer.slow_sql = <%= scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_slow_sql'] %>
 <%- end -%>
 
@@ -485,7 +485,7 @@ newrelic.transaction_tracer.slow_sql = <%= scope['::newrelic::agent::php::newrel
 ;          stack trace for a transaction trace.
 ;
 ;newrelic.transaction_tracer.stack_trace_threshold = 500
-<%- if scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_stack_trace_threshold'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_transaction_tracer_stack_trace_threshold') != :undef -%>
 newrelic.transaction_tracer.stack_trace_threshold = <%= scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_stack_trace_threshold'] %>
 <%- end -%>
 
@@ -499,7 +499,7 @@ newrelic.transaction_tracer.stack_trace_threshold = <%= scope['::newrelic::agent
 ;          requesting explain plans is defined below.
 ;
 ;newrelic.transaction_tracer.explain_enabled = true
-<%- if scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_explain_enabled'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_transaction_tracer_explain_enabled') != :undef -%>
 newrelic.transaction_tracer.explain_enabled = <%= scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_explain_enabled'] %>
 <%- end -%>
 
@@ -516,7 +516,7 @@ newrelic.transaction_tracer.explain_enabled = <%= scope['::newrelic::agent::php:
 ;          Only relevant if explain_enabled above is set to true.
 ;
 ;newrelic.transaction_tracer.explain_threshold = 500
-<%- if scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_explain_threshold'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_transaction_tracer_explain_threshold') != :undef -%>
 newrelic.transaction_tracer.explain_threshold = <%= scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_explain_threshold'] %>
 <%- end -%>
 
@@ -532,7 +532,7 @@ newrelic.transaction_tracer.explain_threshold = <%= scope['::newrelic::agent::ph
 ;          and private customer data.
 ;
 ;newrelic.transaction_tracer.record_sql = "obfuscated"
-<%- if scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_record_sql'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_transaction_tracer_record_sql') != :undef -%>
 newrelic.transaction_tracer.record_sql = <%= scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_record_sql'] %>
 <%- end -%>
 
@@ -546,7 +546,7 @@ newrelic.transaction_tracer.record_sql = <%= scope['::newrelic::agent::php::newr
 ;          separated list of function or class method names.
 ;
 ;newrelic.transaction_tracer.custom = ""
-<%- if scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_custom'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_transaction_tracer_custom') != :undef -%>
 newrelic.transaction_tracer.custom = "<%= scope['::newrelic::agent::php::newrelic_ini_transaction_tracer_custom'] %>"
 <%- end -%>
 
@@ -564,7 +564,7 @@ newrelic.transaction_tracer.custom = "<%= scope['::newrelic::agent::php::newreli
 ;          Note that "drupal" covers only Drupal 6 and 7.
 ;
 ;newrelic.framework = ""
-<%- if scope['::newrelic::agent::php::newrelic_ini_framework'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_framework') != :undef -%>
 newrelic.framework = "<%= scope['::newrelic::agent::php::newrelic_ini_framework'] %>"
 <%- end -%>
 
@@ -607,7 +607,7 @@ newrelic.framework = "<%= scope['::newrelic::agent::php::newrelic_ini_framework'
 ;          expressions.
 ;
 ;newrelic.webtransaction.name.files = ""
-<%- if scope['::newrelic::agent::php::newrelic_ini_webtransaction_name_files'] -%>
+<%- if scope.lookupvar('::newrelic::agent::php::newrelic_ini_webtransaction_name_files') != :undef -%>
 newrelic.webtransaction.name.files = "<%= scope['::newrelic::agent::php::newrelic_ini_webtransaction_name_files'] %>"
 <%- end -%>
 


### PR DESCRIPTION
This change should fix the boolean settings which are TRUE by default. In the current implementation, when they are set to FALSE, they are omitted because the code assumes they are the same as UNDEFINED.