### PR TITLE
Puppet4

### DIFF
--- a/manifests/agent/php.pp
+++ b/manifests/agent/php.pp
@@ -93,11 +93,12 @@ class newrelic::agent::php (
   }
 
   ::newrelic::php::newrelic_ini { $newrelic_php_conf_dir:
-    exec_path            => $newrelic_php_exec_path,
-    newrelic_license_key => $newrelic_license_key,
-    before               => [ File['/etc/newrelic/newrelic.cfg'], Service[$newrelic_php_service] ],
-    require              => Package[$newrelic_php_package],
-    notify               => Service[$newrelic_php_service],
+    newrelic_daemon_proxy => $newrelic_daemon_proxy,
+    exec_path             => $newrelic_php_exec_path,
+    newrelic_license_key  => $newrelic_license_key,
+    before                => [ File['/etc/newrelic/newrelic.cfg'], Service[$newrelic_php_service] ],
+    require               => Package[$newrelic_php_package],
+    notify                => Service[$newrelic_php_service],
   }
 
   file { '/etc/newrelic/newrelic.cfg':

--- a/manifests/agent/php.pp
+++ b/manifests/agent/php.pp
@@ -73,6 +73,7 @@ class newrelic::agent::php (
   $newrelic_daemon_proxy                                 = undef,
   $newrelic_daemon_collector_host                        = undef,
   $newrelic_daemon_auditlog                              = undef,
+  $newrelic_hostname                                     = undef,
 ) inherits ::newrelic {
 
   if ! $newrelic_license_key {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,9 @@
 #
 # Sample Usage:
 #
-class newrelic::params {
+class newrelic::params (
+  $newrelic_handle_repo = true,
+) {
 
   case $::osfamily {
     'RedHat': {
@@ -30,17 +32,19 @@ class newrelic::params {
       $newrelic_service_name  = 'newrelic-sysmond'
       $newrelic_php_package   = 'newrelic-php5'
       $newrelic_php_service   = 'newrelic-daemon'
-      apt::source { 'newrelic':
-        location => 'http://apt.newrelic.com/debian/',
-        repos    => 'non-free',
-        key      => {
-          id         => 'B60A3EC9BC013B9C23790EC8B31B29E5548C16BF',
-          key_source => 'https://download.newrelic.com/548C16BF.gpg',
-        },
-        include  => {
-          src => false,
-        },
-        release  => 'newrelic',
+      if $newrelic_handle_repo {
+        apt::source { 'newrelic':
+          location => 'http://apt.newrelic.com/debian/',
+          repos    => 'non-free',
+          key      => {
+            id         => 'B60A3EC9BC013B9C23790EC8B31B29E5548C16BF',
+            key_source => 'https://download.newrelic.com/548C16BF.gpg',
+          },
+          include  => {
+            src => false,
+          },
+          release  => 'newrelic',
+        }
       }
       case $::operatingsystem {
         'Debian': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,9 +10,7 @@
 #
 # Sample Usage:
 #
-class newrelic::params (
-  $newrelic_handle_repo = true,
-) {
+class newrelic::params {
 
   case $::osfamily {
     'RedHat': {
@@ -32,20 +30,6 @@ class newrelic::params (
       $newrelic_service_name  = 'newrelic-sysmond'
       $newrelic_php_package   = 'newrelic-php5'
       $newrelic_php_service   = 'newrelic-daemon'
-      if $newrelic_handle_repo {
-        apt::source { 'newrelic':
-          location => 'http://apt.newrelic.com/debian/',
-          repos    => 'non-free',
-          key      => {
-            id         => 'B60A3EC9BC013B9C23790EC8B31B29E5548C16BF',
-            key_source => 'https://download.newrelic.com/548C16BF.gpg',
-          },
-          include  => {
-            src => false,
-          },
-          release  => 'newrelic',
-        }
-      }
       case $::operatingsystem {
         'Debian': {
           case $::operatingsystemrelease {

--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -70,6 +70,7 @@ define newrelic::php (
   $newrelic_daemon_proxy                                 = undef,
   $newrelic_daemon_collector_host                        = undef,
   $newrelic_daemon_auditlog                              = undef,
+  $newrelic_hostname                                     = undef,
   ### Deprecated below
   $newrelic_php_conf_appname              = undef,
   $newrelic_php_conf_enabled              = undef,

--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -108,10 +108,11 @@ define newrelic::php (
   }
 
   ::newrelic::php::newrelic_ini { $newrelic_php_conf_dir:
-    newrelic_license_key => $newrelic_license_key,
-    before               => [ File['/etc/newrelic/newrelic.cfg'], Service[$newrelic_php_service] ],
-    require              => Package[$newrelic_php_package],
-    notify               => Service[$newrelic_php_service],
+    newrelic_license_key  => $newrelic_license_key,
+    newrelic_daemon_proxy => $newrelic_daemon_proxy,
+    before                => [ File['/etc/newrelic/newrelic.cfg'], Service[$newrelic_php_service] ],
+    require               => Package[$newrelic_php_package],
+    notify                => Service[$newrelic_php_service],
   }
 
   file { '/etc/newrelic/newrelic.cfg':

--- a/manifests/php/newrelic_ini.pp
+++ b/manifests/php/newrelic_ini.pp
@@ -1,6 +1,7 @@
 # This module should not be used directly. It is used by newrelic::php.
 define newrelic::php::newrelic_ini (
   $newrelic_license_key,
+  $newrelic_daemon_proxy = undef,
   $exec_path,
 ) {
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -50,6 +50,7 @@ define newrelic::server (
   $newrelic_nrsysmond_collector_host = undef,
   $newrelic_nrsysmond_labels         = undef,
   $newrelic_nrsysmond_timeout        = undef,
+  $newrelic_nrsysmond_hostname       = undef,
 ) {
 
   include newrelic

--- a/manifests/server/linux.pp
+++ b/manifests/server/linux.pp
@@ -51,6 +51,7 @@ class newrelic::server::linux (
   $newrelic_nrsysmond_collector_host = undef,
   $newrelic_nrsysmond_labels         = undef,
   $newrelic_nrsysmond_timeout        = undef,
+  $newrelic_nrsysmond_hostname       = undef,
 ) inherits ::newrelic {
 
   if ! $newrelic_license_key {

--- a/templates/newrelic.cfg.erb
+++ b/templates/newrelic.cfg.erb
@@ -202,3 +202,15 @@ collector_host=<%= @newrelic_daemon_collector_host %>
 <%- if @newrelic_daemon_auditlog -%>
 auditlog=<%= @newrelic_daemon_auditlog %>
 <%- end -%>
+
+#
+# Option : hostname
+# Value  : Sets the hostname of the server as it appears in New Relic. The
+# server agent does not support spaces, and special characters besides
+# hyphens -, underscores _, and periods . are discouraged. The name is
+# restricted to 64 characters.
+# Default: OS-level hostname
+#
+<%- if @newrelic_hostname -%>
+hostname=<%= @newrelic_hostname %>
+<%- end -%>

--- a/templates/nrsysmond.cfg.erb
+++ b/templates/nrsysmond.cfg.erb
@@ -169,3 +169,15 @@ labels=<%= @newrelic_nrsysmond_labels %>
 <%- if @newrelic_nrsysmond_timeout -%>
 timeout=<%= @newrelic_nrsysmond_timeout %>
 <%- end -%>
+
+#
+# Option : hostname
+# Value  : Sets the hostname of the server as it appears in New Relic. The
+# server agent does not support spaces, and special characters besides
+# hyphens -, underscores _, and periods . are discouraged. The name is
+# restricted to 64 characters.
+# Default: OS-level hostname
+#
+<%- if @newrelic_nrsysmond_hostname -%>
+hostname=<%= @newrelic_nrsysmond_hostname %>
+<%- end -%>


### PR DESCRIPTION
quickfixes for puppet4 only (appname), the template does not get the variables anymore in puppet4+, this needs a complete rework. 